### PR TITLE
fix get text node recursion; align captured text src with android os

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     <application android:label="flutter_accessibility_service_example" android:name="${applicationName}" android:icon="@mipmap/ic_launcher">
 
 
-        <service android:name="slayer.accessibility.service.flutter_accessibility_service.AccessibilityListener" android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+        <service android:name="slayer.accessibility.service.flutter_accessibility_service.AccessibilityListener" android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE" android:exported="false">
             <intent-filter>
                 <action android:name="android.accessibilityservice.AccessibilityService" />
             </intent-filter>


### PR DESCRIPTION
1. fix get text recursion A->B->A capturing some app2
2. prefer content description to text aligning with android os implementation
3. add missing exported flag