### PR TITLE
Fix: Prevent IllegalArgumentException by Checking BroadcastReceiver Registration Status and some typos

### DIFF
--- a/android/src/main/java/slayer/accessibility/service/flutter_accessibility_service/FlutterAccessibilityServicePlugin.java
+++ b/android/src/main/java/slayer/accessibility/service/flutter_accessibility_service/FlutterAccessibilityServicePlugin.java
@@ -53,6 +53,7 @@ public class FlutterAccessibilityServicePlugin implements FlutterPlugin, Activit
     private Context context;
     private Activity mActivity;
     private boolean supportOverlay = false;
+    private boolean isReceiverRegistered = false;
 
     private Result pendingResult;
     final int REQUEST_CODE_FOR_ACCESSIBILITY = 167;
@@ -87,6 +88,7 @@ public class FlutterAccessibilityServicePlugin implements FlutterPlugin, Activit
             if (Utils.isAccessibilitySettingsOn(context)) {
                 IntentFilter filter = new IntentFilter(BROD_SYSTEM_GLOBAL_ACTIONS);
                 context.registerReceiver(actionsReceiver, filter);
+                isReceiverRegistered = true;
                 Intent intent = new Intent(context, AccessibilityListener.class);
                 intent.putExtra(INTENT_SYSTEM_GLOBAL_ACTIONS, true);
                 context.startService(intent);
@@ -169,7 +171,10 @@ public class FlutterAccessibilityServicePlugin implements FlutterPlugin, Activit
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
         channel.setMethodCallHandler(null);
         eventChannel.setStreamHandler(null);
-        context.unregisterReceiver(actionsReceiver);
+        if (isReceiverRegistered) {
+            context.unregisterReceiver(actionsReceiver);
+            isReceiverRegistered = false;
+        }
     }
     @SuppressLint("WrongConstant")
     @Override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,7 +44,7 @@ class _MyAppState extends State<MyApp> {
     super.initState();
   }
 
-  void handleAccessiblityStream() {
+  void handleAccessibilityStream() {
     foundSearchField = false;
     setText = false;
     if (_subscription?.isPaused ?? false) {
@@ -177,7 +177,7 @@ class _MyAppState extends State<MyApp> {
                     ),
                     const SizedBox(height: 20.0),
                     TextButton(
-                      onPressed: handleAccessiblityStream,
+                      onPressed: handleAccessibilityStream,
                       child: const Text("Start Stream"),
                     ),
                     const SizedBox(height: 20.0),

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -235,11 +235,11 @@ enum GlobalAction {
   /// Action to bring up the Accessibility Button's chooser menu.
   globalActionAccessibilityButtonChooser(12),
 
-  ///Action to trigger the Accessibility Shortcut.
+  /// Action to trigger the Accessibility Shortcut.
   /// This shortcut has a hardware trigger and can be activated by holding down the two volume keys.
   globalActionAccessibilityShortcut(13),
 
-  /// ction to go back.
+  /// Action to go back.
   globalActionBack(1),
 
   /// Action to dismiss the notification shade.

--- a/lib/flutter_accessibility_service.dart
+++ b/lib/flutter_accessibility_service.dart
@@ -40,7 +40,7 @@ class FlutterAccessibilityService {
     }
   }
 
-  /// check if accessibility permession is enebaled
+  /// check if accessibility permission is enabled
   static Future<bool> isAccessibilityPermissionEnabled() async {
     try {
       return await _methodChannel
@@ -78,7 +78,7 @@ class FlutterAccessibilityService {
 
   /// Show an overlay window of `TYPE_ACCESSIBILITY_OVERLAY`
   ///
-  /// Dont forget to add the overlay entrypoint in the main level.
+  /// Don't forget to add the overlay entrypoint in the main level.
   ///
   /// example:
   /// ```dart


### PR DESCRIPTION
### Checker
The app will crash and throw an `IllegalArgumentException`  in the `onDetachedFromEngine()` method when you try to close the app without invoking any method call using the specified channel. 
The reason is it will try to unregister the `actionsReceiver`when it is not registered in the first place. 

### Revision
Also, fixed some typos.